### PR TITLE
Enable pool_pre_ping setting for #4

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,8 @@ class ProductionConfig(Config):
     if os.getenv('DATABASE_URL') is not None:
         SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL').replace('postgres://', 'postgresql://')
 
+    SQLALCHEMY_ENGINE_OPTIONS = {'pool_pre_ping': True}
+
 
 class DevelopmentConfig(Config):
     DEBUG = True


### PR DESCRIPTION
# Description
Fixed issue #4 

Enabled pool_pre_ping setting in SQLAlchemy. 
This is the pessimistic approach to handle disconnect. 
https://docs.sqlalchemy.org/en/14/core/pooling.html#dealing-with-disconnects

Verified the error doesn't occur when after some time of inactivity.

## Type of change
Bug Fix